### PR TITLE
fix crash when no object to correlate with pixels

### DIFF
--- a/bin/do_xMetalGrid.py
+++ b/bin/do_xMetalGrid.py
@@ -151,7 +151,18 @@ if __name__ == '__main__':
     print("reading qsos")
 
     if (ra.size==0):
-        print(" No object to correlate with pixels")
+        out  = fitsio.FITS(args.out,'rw',clobber=True)
+        head = {}
+        head['RPMAX']          = xcf.rp_max
+        head['RTMAX']          = xcf.rt_max
+        head['NT']             = xcf.nt
+        head['NP']             = xcf.np
+        head['LAMBDAABS']      = args.lambda_abs
+        head['LAMBDAABSMETAL'] = args.lambda_abs_metal
+        coord = sp.zeros( xcf.np*xcf.nt )
+        nb    = sp.zeros( xcf.np*xcf.nt,dtype=sp.int64 )
+        out.write([coord,coord,coord,nb],names=['RP','RT','Z','NB'],header=head)
+        out.close()
         sys.exit(1)
 
     xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )

--- a/bin/do_xMetalGrid.py
+++ b/bin/do_xMetalGrid.py
@@ -150,6 +150,10 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
+    if (ra.size==0):
+        print(" No object to correlate with pixels")
+        sys.exit(1)
+
     xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
 
     upix = sp.unique(pix)

--- a/bin/do_xMetalGrid.py
+++ b/bin/do_xMetalGrid.py
@@ -150,24 +150,10 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
-
-    ### If no pairs in the given r_paral range
-    if (ra.size==0):
-        out  = fitsio.FITS(args.out,'rw',clobber=True)
-        head = {}
-        head['RPMAX']          = xcf.rp_max
-        head['RTMAX']          = xcf.rt_max
-        head['NT']             = xcf.nt
-        head['NP']             = xcf.np
-        head['LAMBDAABS']      = args.lambda_abs
-        head['LAMBDAABSMETAL'] = args.lambda_abs_metal
-        coord = sp.zeros( xcf.np*xcf.nt )
-        nb    = sp.zeros( xcf.np*xcf.nt,dtype=sp.int64 )
-        out.write([coord,coord,coord,nb],names=['RP','RT','Z','NB'],header=head)
-        out.close()
-        sys.exit(1)
-
-    xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
+    if (ra.size!=0):
+        xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
+    else:
+        xcf.angmax = 0.
 
     upix = sp.unique(pix)
     for i,ipix in enumerate(upix):
@@ -182,7 +168,7 @@ if __name__ == '__main__':
     xcf.objs = objs
 
     ### Remove pixels if too far from objects
-    if ( (z_min_pix<sp.amin(zqso)) or (sp.amax(zqso)<z_max_pix) ):
+    if ( ra.size!=0 and ( (z_min_pix<sp.amin(zqso)) or (sp.amax(zqso)<z_max_pix)) ):
 
         d_min_pix_cut = cosmo.r_comoving(sp.amin(zqso))+xcf.rp_min
         z_min_pix_cut = cosmo.r_2_z(d_min_pix_cut)

--- a/bin/do_xMetalGrid.py
+++ b/bin/do_xMetalGrid.py
@@ -150,6 +150,8 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
+
+    ### If no pairs in the given r_paral range
     if (ra.size==0):
         out  = fitsio.FITS(args.out,'rw',clobber=True)
         head = {}

--- a/bin/do_xcf.py
+++ b/bin/do_xcf.py
@@ -150,24 +150,10 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
-
-    ### If no pairs in the given r_paral range
-    if (ra.size==0):
-        out  = fitsio.FITS(args.out,'rw',clobber=True)
-        head = {}
-        head['RPMAX'] = xcf.rp_max
-        head['RTMAX'] = xcf.rt_max
-        head['NT']    = xcf.nt
-        head['NP']    = xcf.np
-        coord = sp.zeros( xcf.np*xcf.nt )
-        nb    = sp.zeros( xcf.np*xcf.nt,dtype=sp.int64 )
-        data  = sp.zeros( (0,xcf.np*xcf.nt) )
-        out.write([coord,coord,coord,nb],names=['RP','RT','Z','NB'],header=head)
-        out.write([data,data],names=['WE','DA'])
-        out.close()
-        sys.exit(1)
-
-    xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
+    if (ra.size!=0):
+        xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
+    else:
+        xcf.angmax = 0.
 
     upix = sp.unique(pix)
     for i,ipix in enumerate(upix):
@@ -182,7 +168,7 @@ if __name__ == '__main__':
     xcf.objs = objs
 
     ### Remove pixels if too far from objects
-    if ( (z_min_pix<sp.amin(zqso)) or (sp.amax(zqso)<z_max_pix) ):
+    if ( ra.size!=0 and ( (z_min_pix<sp.amin(zqso)) or (sp.amax(zqso)<z_max_pix)) ):
 
         d_min_pix_cut = cosmo.r_comoving(sp.amin(zqso))+xcf.rp_min
         z_min_pix_cut = cosmo.r_2_z(d_min_pix_cut)

--- a/bin/do_xcf.py
+++ b/bin/do_xcf.py
@@ -150,6 +150,10 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
+    if (ra.size==0):
+        print(" No object to correlate with pixels")
+        sys.exit(1)
+
     xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
 
     upix = sp.unique(pix)

--- a/bin/do_xcf.py
+++ b/bin/do_xcf.py
@@ -151,7 +151,18 @@ if __name__ == '__main__':
     print("reading qsos")
 
     if (ra.size==0):
-        print(" No object to correlate with pixels")
+        out  = fitsio.FITS(args.out,'rw',clobber=True)
+        head = {}
+        head['RPMAX'] = xcf.rp_max
+        head['RTMAX'] = xcf.rt_max
+        head['NT']    = xcf.nt
+        head['NP']    = xcf.np
+        coord = sp.zeros( xcf.np*xcf.nt )
+        nb    = sp.zeros( xcf.np*xcf.nt,dtype=sp.int64 )
+        data  = sp.zeros( (0,xcf.np*xcf.nt) )
+        out.write([coord,coord,coord,nb],names=['RP','RT','Z','NB'],header=head)
+        out.write([data,data],names=['WE','DA'])
+        out.close()
         sys.exit(1)
 
     xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )

--- a/bin/do_xcf.py
+++ b/bin/do_xcf.py
@@ -150,6 +150,8 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
+
+    ### If no pairs in the given r_paral range
     if (ra.size==0):
         out  = fitsio.FITS(args.out,'rw',clobber=True)
         head = {}

--- a/bin/do_xdmat.py
+++ b/bin/do_xdmat.py
@@ -157,26 +157,10 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
-
-    ### If no pairs in the given r_paral range
-    if (ra.size==0):
-        out = fitsio.FITS(args.out,'rw',clobber=True)
-        head = {}
-        head['REJ']    = args.rej
-        head['RPMAX']  = xcf.rp_max
-        head['RPMIN']  = xcf.rp_min
-        head['RTMAX']  = xcf.rt_max
-        head['NT']     = xcf.nt
-        head['NP']     = xcf.np
-        head['NPROR']  = 0.0
-        head['NPUSED'] = 0.0
-        wdm = sp.zeros( xcf.np*xcf.nt )
-        dm  = sp.zeros( (xcf.np*xcf.nt,xcf.np*xcf.nt) )
-        out.write([wdm,dm],names=['WDM','DM'],header=head)
-        out.close()
-        sys.exit(1)
-
-    xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
+    if (ra.size!=0):
+        xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
+    else:
+        xcf.angmax = 0.
 
     upix = sp.unique(pix)
     for i,ipix in enumerate(upix):
@@ -191,7 +175,7 @@ if __name__ == '__main__':
     xcf.objs = objs
 
     ### Remove pixels if too far from objects
-    if ( (z_min_pix<sp.amin(zqso)) or (sp.amax(zqso)<z_max_pix) ):
+    if ( ra.size!=0 and ( (z_min_pix<sp.amin(zqso)) or (sp.amax(zqso)<z_max_pix)) ):
 
         d_min_pix_cut = cosmo.r_comoving(sp.amin(zqso))+xcf.rp_min
         z_min_pix_cut = cosmo.r_2_z(d_min_pix_cut)

--- a/bin/do_xdmat.py
+++ b/bin/do_xdmat.py
@@ -157,6 +157,8 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
+
+    ### If no pairs in the given r_paral range
     if (ra.size==0):
         out = fitsio.FITS(args.out,'rw',clobber=True)
         head = {}

--- a/bin/do_xdmat.py
+++ b/bin/do_xdmat.py
@@ -158,7 +158,20 @@ if __name__ == '__main__':
     print("reading qsos")
 
     if (ra.size==0):
-        print(" No object to correlate with pixels")
+        out = fitsio.FITS(args.out,'rw',clobber=True)
+        head = {}
+        head['REJ']    = args.rej
+        head['RPMAX']  = xcf.rp_max
+        head['RPMIN']  = xcf.rp_min
+        head['RTMAX']  = xcf.rt_max
+        head['NT']     = xcf.nt
+        head['NP']     = xcf.np
+        head['NPROR']  = 0.0
+        head['NPUSED'] = 0.0
+        wdm = sp.zeros( xcf.np*xcf.nt )
+        dm  = sp.zeros( (xcf.np*xcf.nt,xcf.np*xcf.nt) )
+        out.write([wdm,dm],names=['WDM','DM'],header=head)
+        out.close()
         sys.exit(1)
 
     xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )

--- a/bin/do_xdmat.py
+++ b/bin/do_xdmat.py
@@ -157,6 +157,10 @@ if __name__ == '__main__':
     pix = healpy.ang2pix(xcf.nside,th,phi)
     print("reading qsos")
 
+    if (ra.size==0):
+        print(" No object to correlate with pixels")
+        sys.exit(1)
+
     xcf.angmax = 2.*sp.arcsin( xcf.rt_max/(cosmo.r_comoving(z_min_pix)+cosmo.r_comoving(sp.amin(zqso))) )
 
     upix = sp.unique(pix)


### PR DESCRIPTION
fix crash when no object to correlate with pixels given the range in r_perp and r_parallel